### PR TITLE
Wrap deftypes in eval-when form.

### DIFF
--- a/cl-murmurhash.lisp
+++ b/cl-murmurhash.lisp
@@ -2,12 +2,14 @@
 
 (in-package #:cl-murmurhash)
 
-(deftype octet () '(unsigned-byte 8))
+(eval-when (:compile-toplevel :load-toplevel)
 
-(deftype u32 () '(unsigned-byte 32))
+  (deftype octet () '(unsigned-byte 8))
 
-(deftype octet-vector (&optional n)
-  `(simple-array (unsigned-byte 8) (,n)))
+  (deftype u32 () '(unsigned-byte 32))
+
+  (deftype octet-vector (&optional n)
+    `(simple-array (unsigned-byte 8) (,n))))
 
 (deftype -> (args result) `(function ,args ,result))
 


### PR DESCRIPTION
Without this cl-murmurhash does not build in Allegro Lisp 9.0 x64 SMP.
It seems that the problem is the defmethod specialized on
 #.(class-of (make-array 0 :element-type 'octet)) at line 415.
Allegro does not appear to have the type defined until after the file
is completely compiled, a problem I've run into a few times.
